### PR TITLE
Add Shanghai 2024 Legends Stage seedings

### DIFF
--- a/data/2024_shanghai_legends.json
+++ b/data/2024_shanghai_legends.json
@@ -1,0 +1,74 @@
+{
+  "systems": {
+    "valve": "lambda x: x"
+  },
+  "sigma": {
+    "valve": 600
+  },
+  "teams": {
+    "G2": {
+      "seed": 1,
+      "valve": 1964
+    },
+    "NAVI": {
+      "seed": 2,
+      "valve": 1842
+    },
+    "Vitality": {
+      "seed": 3,
+      "valve": 1834
+    },
+    "Spirit": {
+      "seed": 4,
+      "valve": 1824
+    },
+    "Mouz": {
+      "seed": 5,
+      "valve": 1703
+    },
+    "Faze": {
+      "seed": 6,
+      "valve": 1636
+    },
+    "Heroic": {
+      "seed": 7,
+      "valve": 1638
+    },
+    "3DMax": {
+      "seed": 8,
+      "valve": 1497
+    },
+    "Mongolz": {
+      "seed": 9,
+      "valve": 1768
+    },
+    "Liquid": {
+      "seed": 10,
+      "valve": 1603
+    },
+    "GamerLegion": {
+      "seed": 11,
+      "valve": 1372
+    },
+    "Furia": {
+      "seed": 12,
+      "valve": 1560
+    },
+    "Pain": {
+      "seed": 13,
+      "valve": 1491
+    },
+    "Wildcard": {
+      "seed": 14,
+      "valve": 1351
+    },
+    "BIG": {
+      "seed": 15,
+      "valve": 1463
+    },
+    "MIBR": {
+      "seed": 16,
+      "valve": 1373
+    }
+  }
+}


### PR DESCRIPTION
Seedings are the valve global rankings as of December 3rd. Available here: https://www.hltv.org/valve-ranking/teams/2024/december/3